### PR TITLE
Develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.8.3](https://github.com/EdoardoTosin/Zoom-Web-Client-Redirector/tree/v2.8.3) - 2021-09-xx
+
+### Changed
+
+- Corrected `zoomgov.us` domain with `zoomgov.com`.
+- Match any single letter between "/*/" instead of just "/j/".
+
 ## [2.8.2](https://github.com/EdoardoTosin/Zoom-Web-Client-Redirector/tree/v2.8.2) - 2021-09-01
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.8.3](https://github.com/EdoardoTosin/Zoom-Web-Client-Redirector/tree/v2.8.3) - 2021-09-xx
+## [2.8.3](https://github.com/EdoardoTosin/Zoom-Web-Client-Redirector/tree/v2.8.3) - 2021-09-19
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ Zoom Web Client Redirector does **NOT** collect any data of any kind.
 "permissions": [
   "storage",
   "*://*.zoom.us/*",
-  "*://*.zoomgov.us/*"
+  "*://*.zoomgov.com/*"
 ],
 ```
 
 - ``storage`` is used to store the status of the button that is present in the dashboard.  
-- ``*://*.zoom.us/*`` and ``*://*.zoomgov.us/*`` are necessary to get the url and modify it to redirect to the web client page.
+- ``*://*.zoom.us/*`` and ``*://*.zoomgov.com/*`` are necessary to get the url and modify it to redirect to the web client page.
 
 ## Release History
 

--- a/src/js/redirect.js
+++ b/src/js/redirect.js
@@ -5,7 +5,7 @@ if (!storage) storage = chrome.storage.local;
 (function redirect(){
   storage.get("toggle", function(items) {
       //console.log(items.toggle);
-      if (items.toggle=="true" && window.location.pathname!=null && window.location.pathname.substring(0,3) == "/j/"){
+      if (items.toggle=="true" && window.location.pathname!=null && window.location.pathname.substring(0,3).match(/[/]{1}[A-Za-z]{1}[/]{1}/)){
         var domain = window.location.hostname;
         var path = "/wc/join/" + window.location.pathname.substring(3);
         window.location.href = "https://" + domain + path;

--- a/src/js/toggle.js
+++ b/src/js/toggle.js
@@ -61,9 +61,11 @@ function saveOption() {
   else{
     setRedirectOff();
   }
+  /*
   storage.get("toggle", function(items) {
-  //console.log('Set to: ' + items.toggle);
+  console.log('Set to: ' + items.toggle);
   });
+  */
 };
 
 // If toggle change state it calls saveOption function.

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "Zoom Web Client Redirector",
   "short_name": "Zoom WC Red",
-  "version": "2.8.2",
+  "version": "2.8.3",
   "author": "Edoardo Tosin",
   "description": "A web extension that redirects zoom meetings to the web client version.",
   "homepage_url": "https://github.com/EdoardoTosin/Zoom-Web-Client-Redirector",
@@ -16,7 +16,7 @@
   "permissions": [
     "storage",
     "*://*.zoom.us/*",
-    "*://*.zoomgov.us/*"
+    "*://*.zoomgov.com/*"
   ],
   "background": {
     "page": "html/popup.html"
@@ -25,12 +25,12 @@
     {
       "exclude_matches": [
         "*://*.zoom.us/wc/join/*",
-        "*://*.zoomgov.us/wc/join/*",
+        "*://*.zoomgov.com/wc/join/*",
         "file://*/*"
       ],
       "matches": [
         "*://*.zoom.us/*",
-        "*://*.zoomgov.us/*"
+        "*://*.zoomgov.com/*"
       ],
       "js": [
         "js/toggle.js",


### PR DESCRIPTION
### Changed

- Corrected `zoomgov.us` domain with `zoomgov.com`.
- Match any single letter between "/*/" instead of just "/j/".
